### PR TITLE
Add loader to Java example so that Math.random and returning of strings work

### DIFF
--- a/build/js/index.js
+++ b/build/js/index.js
@@ -34,18 +34,18 @@ if (!WebAssembly.instantiateStreaming) {
 
     const defaultReadStringFromMemory = (exports, heap) => utf8ToString(heap, exports.name());
 
-    const defaultWasmLoader = async (wasmFile, readStringFromMemory) => {
+    const defaultWasmLoader = async (wasmFile, readStringFromMemory, importObject = {}) => {
         // For the WebAssembly MVP, there is only one memory for all modules, however
-        // in the future, each module would probably get its own memory    
+        // in the future, each module would probably get its own memory
         const memory = new WebAssembly.Memory({ initial: 2, maximum: 10 });
-        const { mod, instance } = await WebAssembly.instantiateStreaming(fetch(`wasm/${wasmFile}`), {
+        const { mod, instance } = await WebAssembly.instantiateStreaming(fetch(`wasm/${wasmFile}`), Object.assign({
             env: {
                 memory,
                 // Some languages do not support random number generation easily,
                 // so we allow them to reuse JavaScript's API
                 random: () => Math.random()
             }
-        });
+        }, importObject));
 
         const heap = new Uint8Array((instance.exports.memory || memory).buffer);
         const wheelPart = readStringFromMemory(instance.exports, heap);

--- a/src/langs/java/WheelPart.java
+++ b/src/langs/java/WheelPart.java
@@ -1,19 +1,16 @@
 package wheelOfWasm;
 
 import org.teavm.interop.Export;
-import org.teavm.interop.Import;
 
 public class WheelPart {
 
-    // When returing a String from a name() method,
-    // I cannot really read it from the linear memory,
-    // as it gets some spaces inbetween.
+    @Export(name = "name")
+    public String name() {
+    	return "Java";
+    }
 
     @Export(name = "feelingLucky")
     public static int feelingLucky() {
-    	return (int)(WheelPart.random() * 100) + 1;
+    	return (int)(Math.random() * 100) + 1;
     }
-
-    @Import(module = "env", name = "random")
-    private static native double random();
 }

--- a/src/langs/java/build.js
+++ b/src/langs/java/build.js
@@ -1,6 +1,10 @@
+const fs = require('fs');
 const { exec } = require('child_process');
 
 exports.task = (done) => {
+    const buildDir = `${__dirname}/../../../build/wasm`;
+    fs.copyFileSync(`${__dirname}/wasm-loader.js`, `${buildDir}/wheel-part-java.wasm-loader.js`);
+
     const ls = exec('mvn clean install', { cwd: __dirname });
     ls.stdout.pipe(process.stdout)
     ls.stderr.pipe(process.stdout)

--- a/src/langs/java/meta.json
+++ b/src/langs/java/meta.json
@@ -1,3 +1,3 @@
 {
-    "name": "Java"
+    "loader": true
 }

--- a/src/langs/java/wasm-loader.js
+++ b/src/langs/java/wasm-loader.js
@@ -1,0 +1,19 @@
+(() => {
+    const getInt = (heap, offset) => {
+        return heap[offset + 0] |
+            heap[offset + 1] << 8 |
+            heap[offset + 2] << 16 |
+            heap[offset + 3] << 24;
+    };
+
+    const javaToJsString = (heap, offset) => {
+        // Implementation based on https://stackoverflow.com/questions/31206851/how-much-memory-does-a-string-use-in-java-8 and heap dump analysis
+        charArrayOffset = getInt(heap, offset + 8);
+        charArrayLength = getInt(heap, charArrayOffset + 8);
+
+        return String.fromCharCode.apply(String, new Uint16Array(heap.buffer, charArrayOffset + 12, charArrayLength));
+    };
+
+    const readStringFromMemory = (exports, heap) => javaToJsString(heap, exports.name());
+    wheel.defaultWasmLoader('wheel-part-java.wasm', readStringFromMemory, {math: Math})
+})();


### PR DESCRIPTION
I saw the necessity to define the math import object here: https://github.com/konsoletyper/teavm/blob/0.5.1/samples/benchmark/src/main/webapp/teavm-wasm.js.
