### PR TITLE
Run Maven in batch mode.

### DIFF
--- a/src/langs/java/build.js
+++ b/src/langs/java/build.js
@@ -4,7 +4,7 @@ const { exec } = require('child_process');
 exports.task = (done) => {
     const buildDir = `${__dirname}/../../../build/wasm`;
 
-    const ls = exec('mvn clean install', { cwd: __dirname });
+    const ls = exec('mvn -B clean install', { cwd: __dirname });
     ls.stdout.pipe(process.stdout)
     ls.stderr.pipe(process.stdout)
     ls.on('exit', (code) => {


### PR DESCRIPTION
Batch mode suppresses per file download progress output. Downloaded files are still shown. At least with some Node/Gulp versions the progress output causes Gulp to fail for no apparent reason.